### PR TITLE
Change the README link to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This is the [Hugo](https://gohugo.io/) source code for my personal website. It is using the [Blackburn](https://github.com/yoshiharuyamashita/blackburn) theme and gets deployed by [netlify](https://netlify.com/).
 
-You can view the live website [here](http://amirsadoughi.com).
+You can view the live website [here](https://amirsadoughi.com).


### PR DESCRIPTION
Chrome is [going to mark](https://www.theverge.com/2018/2/8/16991254/chrome-not-secure-marked-http-encryption-ssl) all `http` sites as "Not secure" starting in July.

Netlify also [has an option](https://www.netlify.com/docs/ssl/#forcing-ssl) to force `https` if you would like to do that.